### PR TITLE
Fix Ruby class example

### DIFF
--- a/syntax.md
+++ b/syntax.md
@@ -122,6 +122,7 @@ class Sample
 class Sample
     def hello
         "Hello, World!"
+    end
 end
 
 s = Sample.new


### PR DESCRIPTION
Was missing an `end`. 