### PR TITLE
Add semi-colons

### DIFF
--- a/variable-scopes.md
+++ b/variable-scopes.md
@@ -3,10 +3,10 @@
 In the CFML language, there are many persistence and visibility scopes that exist for variables to be placed in.  These are differentiated by context: in a CFC, in a function, tag, thread or in a template.  All CFML scopes are implemented as structures or hash maps of key-value name pairs. The default scope for variable storage is called `variables`.  Thus you can refer variables like this:
 
 ```js
-a = hello
-writeOutput( a )
+a = "hello";
+writeOutput( a );
 or 
-writeOutput( variables.a )
+writeOutput( variables.a );
 ```
 
 ## Persistence Scopes


### PR DESCRIPTION
Earlier in the guide you suggest that semi-colons are always used for cross-engine compatibility, so updating the code snippet to reflect that.
Also think "hello" is supposed to be a string value, so have quoted it.