### PR TITLE
Move link down.

### DIFF
--- a/numbers.md
+++ b/numbers.md
@@ -46,7 +46,6 @@ writeOutput( a ); => 2
 
 As you can see from the example above, in line 2 the output will be now 2, as `a` was incremented before. Same will go for the `--` operator used before operations.
 
-> See https://cfdocs.org/cfloop, https://cfdocs.org/cfwhile for more information
 
 ## Repeating Instructions
 
@@ -64,4 +63,6 @@ while( i <= 10 ){
 ```
 
 > Please note that the syntax varies from tag to script, so refer to the docs for subtle differences. Please also note that you can iterate over structures, arrays, queries and objects in CFML as well; we will see this in later sections.
+
+> See https://cfdocs.org/cfloop, https://cfdocs.org/cfwhile for more information
 


### PR DESCRIPTION
Moved the link to under the 'loop' section title as previously it looked like the link was related to the before operations section.