### PR TITLE
changing <cfml> to (cfml)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Introduction
 
-Welcome to the wonderful world of dynamic programming with ColdFusion &lt;CFML&gt;.  The purpose of this book is to jump start developers into the ColdFusion &lt;CFML&gt; programming language from a **MODERN** perspective and a focus on best practices, object orientation and tooling.  ColdFusion is not the same as it was 20 years ago, yes it's more than 20 years old! 
+Welcome to the wonderful world of dynamic programming with ColdFusion (CFML).  The purpose of this book is to jump start developers into the CFML programming language from a **MODERN** perspective and a focus on best practices, object orientation and tooling.  ColdFusion is not the same as it was 20 years ago, yes it's more than 20 years old! 
 
-It's dynamic, vibrant, modern, fluent, and functional!  Let's begin our adventure into the world of **MODERN** ColdFusion &lt;CFML&gt;.
+It's dynamic, vibrant, modern, fluent, and functional!  Let's begin our adventure into the world of **MODERN** ColdFusion (CFML).
 
 ## Support Open Source
 
@@ -14,5 +14,5 @@ This book is available free of charge online but your support goes a long way to
 
 This book has been written by [Luis Majano](https://www.luismajano.com) and the [Ortus Solutions](https://www.ortussolutions.com) Development Team.
 
-> Ortus Solutions is a company that focuses on building professional open source tools, custom applications and great websites! We're the team behind ColdBox, the de-facto enterprise CFML HMVC Platform, TestBox, the CFML Testing and Behavior Driven Development \(BDD\) Framework, ContentBox, a highly modular and scalable Content Management System, CommandBox, the ColdFusion &lt;CFML&gt; CLI, package manager, etc, and many more - [https://www.ortussolutions.com/](https://www.ortussolutions.com/)
+> Ortus Solutions is a company that focuses on building professional open source tools, custom applications and great websites! We're the team behind ColdBox, the de-facto enterprise CFML HMVC Platform, TestBox, the CFML Testing and Behavior Driven Development \(BDD\) Framework, ContentBox, a highly modular and scalable Content Management System, CommandBox, the ColdFusion (CFML) CLI, package manager, etc, and many more - [https://www.ortussolutions.com/](https://www.ortussolutions.com/)
 


### PR DESCRIPTION
Great job on the book, Luis! That said, I notice some inconsistency where sometimes "ColdFusion <CFML>" is used, but other times "ColdFusion (CFML)". Of course, the latter may be preferred by many, as the former can trigger those with an aversion to tags, or with an aversion to CFML being associated negatively for being tag-based. And given how script is indeed the focus of most of this resource, it does seem better to avoid the brackets.

So I've changed that here. I notice it's already been done in the title in the top left corner of the online book (though the cover of the printed book uses it, and I realize that could be very hard for you to change--though it may be worth pursuing.)