### PR TITLE
Show example of plain multi-line comment

### DIFF
--- a/cfml-language/comments.md
+++ b/cfml-language/comments.md
@@ -21,7 +21,7 @@ If you are within a CFC or in a `<cfscript>` block you can use an alternate styl
 ```java
 
 /**
- * Constructor, called by your Application CFC
+ * Multi-line Javadoc style comment
  *
  * @COLDBOX_CONFIG_FILE The override location of the config file
  * @COLDBOX_APP_ROOT_PATH The location of the app on disk
@@ -31,7 +31,7 @@ If you are within a CFC or in a `<cfscript>` block you can use an alternate styl
  */
 
 
-/**
+/*
   Multi 
   Line
   Comments


### PR DESCRIPTION
Suggest showing a 'plain' multi-line comment as well as the Javadoc style.

Sorry - seem to getting whitespace diffs.

Suggested edit is to show the second multi-line comment with an opening `/*` instead of `/**` as javadoc style can be used for meta data, 'plain' style comments are just ignored.