### PR TITLE
Fix safe navigation operator description in conditionals.md

### DIFF
--- a/cfml-language/conditionals.md
+++ b/cfml-language/conditionals.md
@@ -159,7 +159,7 @@ You can do things like this:
 result = var?.key?.otherKey ?: "";
 ```
 
-The hook operator (`?`) along with the dot operator (`.`) is known as safe navigation operator(`?.`). The safe navigation operator makes sure that if the variable used before the operator is not defined or java `null`, then instead of throwing an error, the operator returns `undefined` for that particular access.
+The hook operator (`?`) along with the dot operator (`.`) is known as safe navigation operator(`?.`). The safe navigation operator makes sure that if the variable used before the operator is not defined or java `null`, then instead of throwing an error, the operator returns `null` for that particular access.
 
 ## Switch, Case, & Default
 


### PR DESCRIPTION
Corrected the explanation of the safe navigation operator to indicate it returns 'null' instead of 'undefined'. Undefined is not defined in the book, but seems to be a mistake. 'null' may be a problem too, if CF does not have null enabled. This section is troublesome to the reader, in any case.